### PR TITLE
Update link to slack invite

### DIFF
--- a/src/components/SectionFaq/index.tsx
+++ b/src/components/SectionFaq/index.tsx
@@ -34,7 +34,7 @@ const SectionFaq = () => (
             </a>{' '}
             ou entrar no{' '}
             <a
-              href="https://slack-willianjusten.herokuapp.com/"
+              href="https://willianjusten-cursos.slack.com/join/shared_invite/zt-g20h37hj-GnSb_y7PXCRjS92N9T8LCQ#/"
               target="_blank"
               rel="noreferrer"
             >


### PR DESCRIPTION
update link to slack invite using native slack solution https://willianjusten-cursos.slack.com/join/shared_invite/zt-g20h37hj-GnSb_y7PXCRjS92N9T8LCQ#/

this pr was a suggestion from this twitter thread https://twitter.com/rafaspawn/status/1296661624493944832